### PR TITLE
Only run getssl if *requested*, ie. a domain's config has changed

### DIFF
--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -196,6 +196,7 @@ define getssl::domain (
   unless $suppress_getssl_run {
     exec { "${base_dir}/getssl -U -w ${base_dir}/conf -q ${domain}":
       path        => ['/bin', '/usr/bin', '/usr/sbin', $base_dir],
+      refreshonly => true,
     }
   }
 }


### PR DESCRIPTION
Addresses #3.  Would appreciate this one being checked over - I have been unable to test it - my machine uses the suppress-getssl changes.