### PR TITLE
Allow setting CHECK_REMOTE_WAIT

### DIFF
--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -36,6 +36,8 @@
 #     Email for registration account. Defaults to undef
 #   [*domain_check_remote*]
 #     BOOL checks if certificate is available and online. Defaults to global configuration.
+#   [*domain_check_remote_wait*]
+#     Seconds to wait after executing reload_command before checking remote certificate.
 #   [*domain_reload_command*]
 #     Set command to reload e.g Webserver. Defaults to Global Command
 #   [*domain_renew_allow*]
@@ -77,6 +79,7 @@ define getssl::domain (
   $domain_account_key_length = $getssl::params::domain_account_key_length,
   $domain_account_mail       = $getssl::params::domain_account_mail,
   $domain_check_remote       = $getssl::params::domain_check_remote,
+  $domain_check_remote_wait  = $getssl::params::domain_check_remote_wait,
   $domain_reload_command     = $getssl::params::domain_reload_command,
   $domain_renew_allow        = $getssl::params::domain_renew_allow,
   $domain_server_type        = $getssl::params::domain_server_type,
@@ -180,6 +183,7 @@ define getssl::domain (
       'domain_cert_location'      => $domain_cert_location,
       'domain_chain_location'     => $domain_chain_location,
       'domain_check_remote'       => $domain_check_remote,
+      'domain_check_remote_wait'  => $domain_check_remote_wait,
       'domain_key_cert_location'  => $domain_key_cert_location,
       'domain_key_location'       => $domain_key_location,
       'domain_pem_location'       => $domain_pem_location,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,6 +32,7 @@ class getssl::params{
   $domain_account_key_length = 4096
   $domain_account_mail       = undef
   $domain_check_remote       = true
+  $domain_check_remote_wait  = undef
   $domain_reload_command     = undef
   $domain_renew_allow        = 30
   $domain_server_type        = 'https'

--- a/templates/domain_getssl.cfg.epp
+++ b/templates/domain_getssl.cfg.epp
@@ -60,3 +60,6 @@ RENEW_ALLOW=<%= $domain_renew_allow %>
 # an update to confirm correct certificate is running (if CHECK_REMOTE) is set to true
 SERVER_TYPE="<%= $domain_server_type -%>"
 CHECK_REMOTE="<%= $domain_check_remote -%>"
+<% if $domain_check_remote_wait { -%>
+CHECK_REMOTE_WAIT="<%= $domain_check_remote_wait -%>"
+<% } -%>


### PR DESCRIPTION
Allows setting delay before checking remote certificate, via domain_check_remote_wait on a domain.